### PR TITLE
Reduce to 592 bytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,14 +18,22 @@ export function *iter(source) {
   let i = 0;
   let newline = -1;
 
-  const length = source.length;
+  let length = source.length;
 
   /** @type {string[]} */
-  const row = [];
+  let row = [];
+
+  /** @type {string} */
+  let s;
+  /** @type {number} */
+  let char;
+  /** @type {number} */
+  let index;
 
   while (i < length) {
     // we consume at most one col per outer loop
-    let s = '';
+    s = '';
+    char = source.charCodeAt(i);
 
     if (i > newline) {
       newline = source.indexOf('\n', i);
@@ -34,29 +42,28 @@ export function *iter(source) {
       }
     }
 
-    const start = source.charCodeAt(i);
-    if (start === C_NEWLINE) {
+    if (char === C_NEWLINE) {
       yield row.splice(0, row.length);
       ++i;
       continue;
 
-    } else if (start === C_QUOTE) {
+    } else if (char === C_QUOTE) {
       // consume many parts of quoted string
       for (; ;) {
-        let next = source.indexOf('"', i + 1);
-        if (next < 0) {
-          next = length;
+        index = source.indexOf('"', i + 1);
+        if (index < 0) {
+          index = length;
         }
-        s += source.substring(i + 1, next);
+        s += source.substring(i + 1, index);
 
-        i = next + 1;
+        i = index + 1;
         if (i >= length) {
           break;  // end of input
         }
-        const check = source.charCodeAt(i);
-        if (check === C_COMMA || check === C_NEWLINE) {
+        char = source.charCodeAt(i);
+        if (char === C_COMMA || char === C_NEWLINE) {
           break;  // end of string
-        } else if (check !== C_QUOTE) {
+        } else if (char !== C_QUOTE) {
           --i;  // allow missing double quote _anyway_
         }
         s += '"';
@@ -65,13 +72,13 @@ export function *iter(source) {
     } else {
       // this is a "normal" value, ends with a comma or newline
       // look for comma first (educated guess)
-      let to = source.indexOf(',', i);
-      if (to < 0 || newline < to) {
-        to = newline;
+      index = source.indexOf(',', i);
+      if (index < 0 || newline < index) {
+        index = newline;
       }
 
-      s = source.substring(i, to);
-      i = to;
+      s = source.substring(i, index);
+      i = index;
     }
 
     row.push(s);

--- a/index.js
+++ b/index.js
@@ -42,12 +42,12 @@ export function *iter(source) {
       }
     }
 
-    if (char === C_NEWLINE) {
+    if (char == C_NEWLINE) {
       yield row.splice(0, row.length);
       ++i;
       continue;
 
-    } else if (char === C_QUOTE) {
+    } else if (char == C_QUOTE) {
       // consume many parts of quoted string
       for (; ;) {
         index = source.indexOf('"', i + 1);
@@ -61,9 +61,9 @@ export function *iter(source) {
           break;  // end of input
         }
         char = source.charCodeAt(i);
-        if (char === C_COMMA || char === C_NEWLINE) {
+        if (char == C_COMMA || char == C_NEWLINE) {
           break;  // end of string
-        } else if (char !== C_QUOTE) {
+        } else if (char != C_QUOTE) {
           --i;  // allow missing double quote _anyway_
         }
         s += '"';
@@ -84,7 +84,7 @@ export function *iter(source) {
     row.push(s);
 
     // look for ,
-    if (source.charCodeAt(i) === C_COMMA) {
+    if (source.charCodeAt(i) == C_COMMA) {
       ++i;
     }
   }

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ const r = (raw) => {
   if (!needsQuoteRegexp.test(raw)) {
     return raw;
   }
-  return '"' + raw.replace(globalQuote, '""') + '"';
+  return `"${raw.replace(globalQuote, '""')}"`;
 };
 
 

--- a/index.js
+++ b/index.js
@@ -18,21 +18,20 @@ export function *iter(source) {
   let i = 0;
   let newline = -1;
 
-  /**
-   * @param {number} arg
-   * @return {number}
-   */
-  const convertToLength = (arg) => arg === -1 ? source.length : arg;
+  const length = source.length;
 
   /** @type {string[]} */
   const row = [];
 
-  while (i < source.length) {
+  while (i < length) {
     // we consume at most one col per outer loop
     let s = '';
 
     if (i > newline) {
-      newline = convertToLength(source.indexOf('\n', i));
+      newline = source.indexOf('\n', i);
+      if (newline < 0) {
+        newline = length;
+      }
     }
 
     const start = source.charCodeAt(i);
@@ -44,11 +43,14 @@ export function *iter(source) {
     } else if (start === C_QUOTE) {
       // consume many parts of quoted string
       for (; ;) {
-        const next = convertToLength(source.indexOf('"', i + 1));
+        let next = source.indexOf('"', i + 1);
+        if (next < 0) {
+          next = length;
+        }
         s += source.substring(i + 1, next);
 
         i = next + 1;
-        if (i >= source.length) {
+        if (i >= length) {
           break;  // end of input
         }
         const check = source.charCodeAt(i);
@@ -63,8 +65,8 @@ export function *iter(source) {
     } else {
       // this is a "normal" value, ends with a comma or newline
       // look for comma first (educated guess)
-      let to = convertToLength(source.indexOf(',', i));
-      if (newline < to) {
+      let to = source.indexOf(',', i);
+      if (to < 0 || newline < to) {
         to = newline;
       }
 


### PR DESCRIPTION
Some unrelated commits:

- Inline `convertToLength`, with a special case for commas. Normally, it'd look like

  ```ts
  let to = source.indexOf(',', i);
  if (to < 0) {
    to = source.length;
  }
  if (newline < to) {
    to = newline;
  }
  ```
  
  but as we know that `newline <= source.length`, if `to === source.length` then the result of the second if statement is always `to === newline` - so we can merge them to

  ```ts
  let to = source.indexOf(',', i);
  if (to < 0 || newline < to) {
    to = newline;
  }
  ```

  This commit reduces the size down to 637 (-8) bytes, and seems to slightly improve performance too.

- Change all variable definitions in `iters` to be at the top-level as a `let` declaration. This saves repeatedly having `let`s and `const`s in the declaration. This also renames some variables so they can be shared to further reduce size. Note that `char` and `index` could be combined to one variable to save 2 bytes, but would make the code even more hard to understand than it currently is.

  This commit, with the above commit, reduces the size down to 599 (-38) bytes and doesn't seem to affect performance.

- Change `===` to `==`, saving 6 bytes (down to 593) without negatively affecting performance.
- Change `r` to use a template string... saving 1 byte.

Feel free to cherry-pick certain parts of this PR if needed.