### PR TITLE
Change const variables to let

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ export function *iter(source) {
   /** @type {number} */
   let temp;
 
-  const sourceCharCodeAt = () => source.charCodeAt(i);
-  const substringIToTemp = () => source.substring(i, temp);
+  let sourceCharCodeAt = () => source.charCodeAt(i);
+  let substringIToTemp = () => source.substring(i, temp);
 
   for (;;) {
     // we consume at most one col per outer loop


### PR DESCRIPTION
This allows a minifier to combine the let declarations into a single statement.

I'm typing this on my phone so I have no idea how much this will affect size, but I think it's at least ~~8~~ 6 bytes worth of savings.