### PR TITLE
Factor out use of indexOf (528)

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ export function *iter(source) {
 
   let sourceCharCodeAt = () => source.charCodeAt(i);
   let substringIToTemp = () => source.substring(i, temp);
+  let nextIndex = (/** @type {string} */ c) => source.indexOf(c, i);
 
   for (;;) {
     // we consume at most one col per outer loop
@@ -43,7 +44,7 @@ export function *iter(source) {
     }
 
     if (i > newline) {
-      newline = source.indexOf('\n', i);
+      newline = nextIndex('\n');
       if (newline < 0) {
         newline = length;
       }
@@ -54,7 +55,7 @@ export function *iter(source) {
       // consume many parts of quoted string
       for (; ;) {
         ++i;
-        temp = source.indexOf('"', i);
+        temp = nextIndex('"');
         if (temp < 0) {
           temp = length;
         }
@@ -73,7 +74,7 @@ export function *iter(source) {
     } else {
       // this is a "normal" value, ends with a comma or newline
       // look for comma first (educated guess)
-      temp = source.indexOf(',', i);
+      temp = nextIndex(',');
       if (temp < 0 || newline < temp) {
         temp = newline;
       }

--- a/index.js
+++ b/index.js
@@ -27,10 +27,13 @@ export function *iter(source) {
 
   /** @type {number} */
   let temp;
+  /** @type {number} */
+  let temp2;
 
   let sourceCharCodeAt = () => source.charCodeAt(i);
   let substringIToTemp = () => source.substring(i, temp);
-  let nextIndex = (/** @type {string} */ c) => source.indexOf(c, i);
+  let nextIndex = (/** @type {string} */ c) =>
+      (temp2 = source.indexOf(c, i)) < 0 ? length : temp2;
 
   for (;;) {
     // we consume at most one col per outer loop
@@ -45,9 +48,6 @@ export function *iter(source) {
 
     if (i > newline) {
       newline = nextIndex('\n');
-      if (newline < 0) {
-        newline = length;
-      }
     }
 
     if (sourceCharCodeAt() == C_QUOTE) {
@@ -56,9 +56,6 @@ export function *iter(source) {
       for (; ;) {
         ++i;
         temp = nextIndex('"');
-        if (temp < 0) {
-          temp = length;
-        }
         s += substringIToTemp();
 
         i = temp + 1;
@@ -75,7 +72,7 @@ export function *iter(source) {
       // this is a "normal" value, ends with a comma or newline
       // look for comma first (educated guess)
       temp = nextIndex(',');
-      if (temp < 0 || newline < temp) {
+      if (newline < temp) {
         temp = newline;
       }
 


### PR DESCRIPTION
a770bbe08f0ecf0507d2d3deb0ddd3362c7a5ee1 "factored out" `charCodeAt` and `substring`, saving some bytes. However, it also slightly slowed down parsing, too.

These two commits do the same for `indexOf` and the length assignment. This saves 27 bytes... and also slightly slows down parsing, like the aforementioned commit.